### PR TITLE
fillo 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# fillo [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/fillo.svg)](https://www.npmjs.com/package/fillo) [![Downloads](https://img.shields.io/npm/dt/fillo.svg)](https://www.npmjs.com/package/fillo) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# fillo
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/fillo.svg)](https://www.npmjs.com/package/fillo) [![Downloads](https://img.shields.io/npm/dt/fillo.svg)](https://www.npmjs.com/package/fillo) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Fill a value with characters to the given size.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fillo",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Fill a value with characters to the given size.",
   "main": "lib/index.js",
   "directories": {
@@ -33,6 +33,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
