### PR TITLE
#fixes : checked for type before it is used to call the repeat method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,5 +14,5 @@ module.exports = function fillo (what, size, ch) {
     ch = ch || "0";
     what = what.toString();
     var howMany = size - what.length;
-    return (howMany <= 0 ? "" : ch.repeat(howMany)) + what;
+    return (howMany <= 0 ? "" : String(ch).repeat(howMany)) + what;
 };

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
     "bloggify.js",
     "bloggify.json",
     "bloggify/"
+  ],
+
+  "contributors": [
+       "Gaurav Kumar Kashyap <gauravkumarkashyap74354@gmail.com>"
   ]
+
 }


### PR DESCRIPTION
#fixes : 
The bug in the code is that the ch parameter is not being checked for type before it is used to call the repeat() method. This could lead to a TypeError if the parameter is not a string.  To fix the bug, you can add a type assertion to the ch parameter before calling the repeat() method.